### PR TITLE
Fix vid_restart exploits

### DIFF
--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -1075,6 +1075,14 @@ void CL_StartHunkUsers( void ) {
 //	if ( !cls.cgameStarted && cls.state > CA_CONNECTED && cls.state != CA_CINEMATIC ) {
 	if ( !cls.cgameStarted && cls.state > CA_CONNECTED && (cls.state != CA_CINEMATIC && !CL_IsRunningInGameCinematic()) ) 
 	{
+		// Usually the timer should already have been paused by a vid_restart, quickload, map change, ...
+		// But if just now we had the bugged cinematic case mentioned above, that will not be the case,
+		// so to make sure let's pause now.
+		// The timer should always be paused for this init anyways cause it completely blocks Com_Frame,
+		// meaning neither player nor server can ever do anything during it. So we don't have to worry
+		// about special cases where we don't want to pause here.
+		SpeedrunPauseTimer();
+
 		cls.cgameStarted = qtrue;
 		CL_InitCGame();
 	}

--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -1060,6 +1060,17 @@ void CL_StartHunkUsers( void ) {
 		cls.uiStarted = qtrue;
 		CL_InitUI();
 	}
+	
+	if ( !cls.cgameStarted && cls.state > CA_CONNECTED && cls.state != CA_CINEMATIC ) {
+		if (CL_IsRunningInGameCinematic()) {
+			// This is a special somewhat bugged case:
+			// We are basically all ready and would usually start all client stuff now so that the player can start playing,
+			// but somehow a cinematic is playing despite cls.state not being CA_CINEMATIC so we are not starting cgame.
+			// But that means that we would never enter CL_FirstSnapshot to unpause the timer. But we need to have the timer
+			// running during cinematics, because they are skippable. So let's unpause it now.
+			SpeedrunUnpauseTimer();
+		}
+	}
 
 //	if ( !cls.cgameStarted && cls.state > CA_CONNECTED && cls.state != CA_CINEMATIC ) {
 	if ( !cls.cgameStarted && cls.state > CA_CONNECTED && (cls.state != CA_CINEMATIC && !CL_IsRunningInGameCinematic()) ) 

--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -413,6 +413,21 @@ Restart the video subsystem
 */
 void CL_Vid_Restart_f( void ) {
 	SpeedrunPauseTimer();
+	if (cls.cgameStarted || cls.rendererStarted || cls.uiStarted || cls.soundRegistered
+#ifdef __IMMERSION
+		|| cls.forceStarted
+#endif
+	) {
+		// vid_restart will cause the next CL_Frame to run CL_StartHunkUsers which
+		// takes quite some time, blocking the current Com_Frame. So when eventually
+		// we move on to the next Com_Frame, the time delta to the previous frame
+		// will be huge. This delta will be capped to 200msec and passed to
+		// SV_Frame, meaning that we advance level time by 200msec while we had the
+		// timer paused for the vid_restart. So to avoid saving speedrun time in
+		// sections where waiting for gametime to pass by spamming vid_restart, we
+		// have to add these 200 msec.
+		SpeedrunTimerAddMilliseconds(200);
+	}
 
 	S_StopAllSounds();		// don't let them loop during the restart
 	S_BeginRegistration();	// all sound handles are now invalid


### PR DESCRIPTION
This aims to fix two separate timer exploits using vid_restart:

**1. Fix vid_restart spam timer exploit**

Spamming vid_restart would advance server time while the speedrun timer is paused, allowing to save time during sections where you are waiting for stuff to happen in the level. This fixes that by adding the advancement of server time as penalty to the speedrun timer.

**2. Fix vid_restart exploit during cinematics**

vid_restart during cinematics would sometimes cause the speedrun timer to not unpause properly when the game was reloaded and the cinematic started playing. That could be used to save time at the start of yavin_temple for instance. This fixes that by making sure the timer is unpaused even in this somewhat bugged state with a cinematic playing without cgame running