### PR TITLE
Fix not precached assets

### DIFF
--- a/code/cgame/cg_main.cpp
+++ b/code/cgame/cg_main.cpp
@@ -1733,7 +1733,7 @@ Ghoul2 Insert End
 	{
 		if(&g_entities[i])
 		{
-			std::string npcType = g_entities[i].NPC_type && g_entities[i].NPC_type[0] ? g_entities[i].NPC_type : "";
+			std::string npcType = g_entities[i].NPC_type ? g_entities[i].NPC_type : "";
 			std::transform(npcType.begin(), npcType.end(), npcType.begin(),
 			               [](unsigned char c) { return tolower(c); });
 
@@ -1772,8 +1772,6 @@ Ghoul2 Insert End
 	cg.loadLCARSStage = 9;
 
 	NPCsPrecached = qtrue;
-
-	npc_precachedTypes.clear();
 
 	extern	cvar_t	*com_buildScript;
 

--- a/code/cgame/cg_main.cpp
+++ b/code/cgame/cg_main.cpp
@@ -13,6 +13,7 @@
 #ifdef _IMMERSION
 #include "../ff/ff.h"
 #endif // _IMMERSION
+#include <unordered_set>
 #include "../qcommon/sstring.h"
 //NOTENOTE: Be sure to change the mirrored code in g_shared.h
 typedef	map< sstring_t, unsigned char, less<sstring_t>, allocator< unsigned char >  >	namePrecache_m;
@@ -1657,6 +1658,7 @@ static void CG_RegisterGraphics( void ) {
 	cgs.media.shadowMarkShader	= cgi_R_RegisterShader( "markShadow" );
 	cgs.media.wakeMarkShader	= cgi_R_RegisterShader( "wake" );
 	cgi_S_RegisterSound( "sound/effects/energy_crackle.wav" );
+	cgi_R_RegisterShader("gfx/effects/burn"); // func_rotating_touch
 
 
 	CG_LoadingString("map brushes");
@@ -1725,10 +1727,16 @@ Ghoul2 Insert End
 		CG_NewClientinfo( i );
 	}
 
+	std::unordered_set<string> npc_precachedTypes;
+
 	for (i=0 ; i < ENTITYNUM_WORLD ; i++)
 	{
 		if(&g_entities[i])
 		{
+			std::string npcType = g_entities[i].NPC_type && g_entities[i].NPC_type[0] ? g_entities[i].NPC_type : "";
+			std::transform(npcType.begin(), npcType.end(), npcType.begin(),
+			               [](unsigned char c) { return tolower(c); });
+
 			if(g_entities[i].client)
 			{
 				//if(!g_entities[i].client->clientInfo.infoValid)
@@ -1738,17 +1746,24 @@ Ghoul2 Insert End
 					CG_RegisterClientModels(i);
 					if ( i != 0 )
 					{//Client weapons already precached
-						CG_RegisterWeapon( g_entities[i].client->ps.weapon );
-						CG_RegisterNPCCustomSounds( &g_entities[i].client->clientInfo );
-						CG_RegisterNPCEffects( g_entities[i].client->playerTeam );
+						// sometimes neither NPC's model/skin is in config string nor spawner for this npc type is in
+						// g_entities (already freed). So precache here to be safe. Happens for: impcommander/gonk on
+						// artus_detention (level change from mine); prisoner on artus_topside (skipping start cutscene
+						// + vid_restart).
+						if (npc_precachedTypes.emplace(npcType).second)
+						{
+							NPC_Precache( &g_entities[i] );
+						}
 					}
 				}
 			}
-			else if ( g_entities[i].svFlags & SVF_NPC_PRECACHE && g_entities[i].NPC_type && g_entities[i].NPC_type[0] )
+			else if ( g_entities[i].svFlags & SVF_NPC_PRECACHE && !npcType.empty() )
 			{//Precache the NPC_type
-				//FIXME: make sure we didn't precache this NPC_type already
 				CG_LoadingString( va("NPC %s", g_entities[i].NPC_type ) );
-				NPC_Precache( &g_entities[i] );
+				if (npc_precachedTypes.emplace(npcType).second)
+				{
+					NPC_Precache( &g_entities[i] );
+				}
 			}
 		}
 	}
@@ -1757,6 +1772,8 @@ Ghoul2 Insert End
 	cg.loadLCARSStage = 9;
 
 	NPCsPrecached = qtrue;
+
+	npc_precachedTypes.clear();
 
 	extern	cvar_t	*com_buildScript;
 

--- a/code/cgame/cg_weapons.cpp
+++ b/code/cgame/cg_weapons.cpp
@@ -81,7 +81,7 @@ void CG_RegisterWeapon( int weaponNum ) {
 		{
 			*spot = 0;
 			spot = strstr(weaponModel, "_w");//i'm using the in view weapon array instead of scanning the item list, so put the _w back on
-			if (!spot) 
+			if (!spot&&!strstr(weaponModel, "noweap"))
 			{
 				strcat (weaponModel, "_w");
 			}
@@ -644,6 +644,8 @@ void CG_RegisterItemVisuals( int itemNum ) {
 			theFxScheduler.RegisterEffect( "env/small_explode");
 
 			CG_RegisterWeapon( WP_BLASTER );
+
+			cgi_R_RegisterModel( "models/players/remote/lower.md3" );
 			break;
 
 		case INV_SENTRY:

--- a/code/client/snd_dma.cpp
+++ b/code/client/snd_dma.cpp
@@ -4269,7 +4269,7 @@ void S_StartBackgroundTrack( const char *intro, const char *loop, qboolean bCall
 
 	// if dynamic music not allowed, then just stream the explore music instead of playing dynamic...
 	//
-	if (!s_allowDynamicMusic->integer && Music_DynamicDataAvailable(intro))	// "intro", NOT "sName" (i.e. don't use version with ".mp3" extension)
+	if (!s_allowDynamicMusic->integer && !strstr(sName,"/") && Music_DynamicDataAvailable(intro)) // play the explore music of the current level or intro
 	{
 		LPCSTR psMusicName = Music_GetFileNameForState( eBGRNDTRACK_DATABEGIN );
 		if (psMusicName && S_FileExists( psMusicName ))

--- a/code/client/snd_dma.cpp
+++ b/code/client/snd_dma.cpp
@@ -4269,7 +4269,8 @@ void S_StartBackgroundTrack( const char *intro, const char *loop, qboolean bCall
 
 	// if dynamic music not allowed, then just stream the explore music instead of playing dynamic...
 	//
-	if (!s_allowDynamicMusic->integer && !strstr(sName,"/") && Music_DynamicDataAvailable(intro)) // play the explore music of the current level or intro
+    // Speed-Outcast precache fix: if sName is a path we expect Music_DynamicDataAvailable to fail since it expects a levelname, so we skip it to avoid reading dms.dat unnecessarily
+	if (!s_allowDynamicMusic->integer && !strstr(sName,"/") && Music_DynamicDataAvailable(intro))	// "intro", NOT "sName" (i.e. don't use version with ".mp3" extension)
 	{
 		LPCSTR psMusicName = Music_GetFileNameForState( eBGRNDTRACK_DATABEGIN );
 		if (psMusicName && S_FileExists( psMusicName ))

--- a/code/game/NPC_spawn.cpp
+++ b/code/game/NPC_spawn.cpp
@@ -486,7 +486,7 @@ int NPC_WeaponsForTeam( team_t team, int spawnflags, const char *NPC_type )
 			return WP_NONE;
 		}
 
-		if ( Q_strncmp( "weequay", NPC_type, 7 ) == 0 )
+		if ( Q_stricmpn( "weequay", NPC_type, 7 ) == 0 )
 		{
 			return ( 1 << WP_BOWCASTER);//|( 1 << WP_STAFF )(FIXME: new weap?)
 		}

--- a/code/game/NPC_stats.cpp
+++ b/code/game/NPC_stats.cpp
@@ -682,7 +682,7 @@ void NPC_PrecacheWeapons( team_t playerTeam, int spawnflags, char *NPCtype )
 			if (char *spot = strstr(weaponModel, ".md3") ) {
 				*spot = 0;
 				spot = strstr(weaponModel, "_w");//i'm using the in view weapon array instead of scanning the item list, so put the _w back on
-				if (!spot) {
+				if (!spot&&!strstr(weaponModel, "noweap")) {
 					strcat (weaponModel, "_w");
 				}
 				strcat (weaponModel, ".glm");	//and change to ghoul2

--- a/code/game/g_ICARUS.cpp
+++ b/code/game/g_ICARUS.cpp
@@ -20,6 +20,8 @@ extern	void	Q3_DebugPrint( int level, const char *format, ... );
 int			ICARUS_entFilter = -1;
 
 extern	stringID_table_t setTable[];
+extern	stringID_table_t INVTable[];
+extern	stringID_table_t WPTable[];
 
 /*
 =============
@@ -504,6 +506,22 @@ extern	cvar_t	*com_buildScript;
 				case SET_ADDLHANDBOLT_MODEL:
 					{
 						gi.G2API_PrecacheGhoul2Model( sVal2 );
+					}
+					break;
+				// cache items from SET_ITEM, SET_WEAPON beforehand (ns_starpad\force-weapons_ns3)
+				case SET_ITEM:
+					{
+						int inv = GetIDForString( INVTable, sVal2 );
+						gitem_t *item = FindItemForInventory(inv);
+						RegisterItem( item );
+					}
+					break;
+				case SET_WEAPON:
+					{
+						int wp = GetIDForString( WPTable, sVal2 );
+						if (wp <= WP_NONE) break;
+						gitem_t *item = FindItemForWeapon( (weapon_t) wp);
+						RegisterItem( item );
 					}
 					break;
 				default:

--- a/code/game/g_client.cpp
+++ b/code/game/g_client.cpp
@@ -42,6 +42,9 @@ void SP_info_player_deathmatch(gentity_t *ent) {
 		RegisterItem( FindItemForWeapon( WP_SABER ) );	//these are given in ClientSpawn(), but we register them now before cgame starts
 		G_SkinIndex("models/players/kyle/model_fpls2.skin");	//preache the skin used in cg_players.cpp
 	}
+
+	extern void NPC_PrecacheAnimationCFG( const char *NPC_type );
+	NPC_PrecacheAnimationCFG("kyle");
 }
 
 /*QUAKED info_player_start (1 0 0) (-16 -16 -24) (16 16 32) KEEP_PREV DROPTOFLOOR x x x STUN_BATON NOWEAPON x
@@ -1255,18 +1258,6 @@ void G_SetG2PlayerModel( gentity_t * const ent, const char *modelName, const cha
 	{//try the stormtrooper as a default
 		modelName = "stormtrooper";
 		ent->playerModel = gi.G2API_InitGhoul2Model( ent->ghoul2, va("models/players/%s/model.glm", modelName), G_ModelIndex( va("models/players/%s/model.glm", modelName) ), NULL, NULL, 0, 0 );
-	}
-
-	if ( !Q_stricmp( "kyle", modelName ))
-	{
-		// Try to get the skin we'll use when we switch to the first person light saber.  
-		//	We use a new skin to disable certain surfaces so they are not drawn but we can still collide against them
-		int skin = gi.RE_RegisterSkin( "models/players/kyle/model_fpls.skin" );
-		if ( skin )
-		{
-			// put it in the config strings
-			G_SkinIndex( skinName );
-		}
 	}
 
 	// did we find a ghoul2 model? if so, load the animation.cfg file

--- a/code/game/g_mover.cpp
+++ b/code/game/g_mover.cpp
@@ -2283,6 +2283,7 @@ void SP_func_rotating (gentity_t *ent) {
 	{
 		ent->e_TouchFunc = touchF_func_rotating_touch;
 		G_SoundIndex( "sound/effects/energy_crackle.wav" );
+		G_EffectIndex("disruptor/death_smoke");
 	}
 
 	gi.linkentity( ent );

--- a/code/renderer/tr_draw.cpp
+++ b/code/renderer/tr_draw.cpp
@@ -953,41 +953,6 @@ qboolean RE_InitDissolve(qboolean bForceCircularExtroWipe)
 			// ... and load appropriate graphics...
 			//
 
-			// special tweak, although this code is normally called just before client spawns into world (and
-			//	is therefore pretty much immune to precache issues) I also need to make sure that the inverse
-			//	iris graphic is loaded so for the special case of doing a circular wipe at the end of the last
-			//	level doesn't stall on loading the image. So I'll load it here anyway - to prime the image - 
-			//	then allow the random wiper to overwrite the ptr if needed. This way the end of level call
-			//	will be instant.  Downside: every level has one extra 256x256 texture.
-			{
-					Dissolve.pDissolve = R_FindImageFile(	"gfx/2d/iris_mono_rev",		// const char *name
-															qfalse,						// qboolean mipmap
-															qfalse,						// qboolean allowPicmip
-															qfalse,						// qboolean allowTC
-															GL_CLAMP					// int glWrapClampMode 
-														);
-			}
-
-
-			extern cvar_t *com_buildScript;
-			if (com_buildScript->integer)
-			{
-				// register any/all of the possible CASE statements below...
-				//
-				Dissolve.pDissolve = R_FindImageFile(	"gfx/2d/iris_mono",			// const char *name
-														qfalse,						// qboolean mipmap
-														qfalse,						// qboolean allowPicmip
-														qfalse,						// qboolean allowTC
-														GL_CLAMP					// int glWrapClampMode 
-													);
-				Dissolve.pDissolve = R_FindImageFile(	"textures/common/dissolve",	// const char *name
-														qfalse,						// qboolean mipmap
-														qfalse,						// qboolean allowPicmip
-														qfalse,						// qboolean allowTC
-														GL_REPEAT					// int glWrapClampMode 
-													);
-			}
-
 			switch (Dissolve.eDissolveType)
 			{
 				case eDISSOLVE_CIRCULAR_IN:

--- a/code/renderer/tr_model.cpp
+++ b/code/renderer/tr_model.cpp
@@ -389,6 +389,29 @@ int RE_RegisterMedia_GetLevel(void)
 	return giRegisterMedia_CurrentLevel;
 }
 
+static void RE_PrecacheDissolveImages()
+{
+	R_FindImageFile(	"gfx/2d/iris_mono_rev",		// const char *name
+											qfalse,						// qboolean mipmap
+											qfalse,						// qboolean allowPicmip
+											qfalse,						// qboolean allowTC
+											GL_CLAMP					// int glWrapClampMode
+										);
+
+	R_FindImageFile(	"gfx/2d/iris_mono",			// const char *name
+											qfalse,						// qboolean mipmap
+											qfalse,						// qboolean allowPicmip
+											qfalse,						// qboolean allowTC
+											GL_CLAMP					// int glWrapClampMode
+										);
+	R_FindImageFile(	"textures/common/dissolve",	// const char *name
+											qfalse,						// qboolean mipmap
+											qfalse,						// qboolean allowPicmip
+											qfalse,						// qboolean allowTC
+											GL_REPEAT					// int glWrapClampMode
+										);
+}
+
 extern qboolean SND_RegisterAudio_LevelLoadEnd(qboolean bDeleteEverythingNotUsedThisLevel);
 
 void RE_RegisterMedia_LevelLoadEnd(void)
@@ -396,6 +419,12 @@ void RE_RegisterMedia_LevelLoadEnd(void)
 	RE_RegisterModels_LevelLoadEnd(qfalse);
 	RE_RegisterImages_LevelLoadEnd();
 	SND_RegisterAudio_LevelLoadEnd(qfalse);
+
+	// Without this, RE_InitDissolve call from SCR_StopCinematic causes unprecached issue in the following scenarios:
+	// 1. First snapshot RE_InitDissolve loaded different dissolve image (eDissolveType is random);
+	// 2. vid_restart cleared allocated images, if gbAllowScreenDissolve is 0, no dissolved images are precached;
+	// 3. Loaded saved game from other level
+	RE_PrecacheDissolveImages();
 
 	if (gbAllowScreenDissolve)
 	{


### PR DESCRIPTION
### Issues
1\. Start of artus_detention (map transition from artus_mine): impcommander, gonk skins are not precahed.
2. artus_topside (skip into intro cutscene + vid_restart): prisoner's .tga files not precached.
3. Start of ns_streets (map transition from yavin_trial): some skins / bowcaster not precached.
4. ns_hideout elevator weequays spawn (if player has no bowcaster).
5. Start of ns_starpad (if player has no light amplifier goggles).
6. Not precached disruptor assets (executing map meowtrack).
7. cairn_reactor scripted pilot or player touching rotating entities: death effects not precached.
8. Dissolve images sometimes are not precached on stopping cinematic.
9. ext_data/dms.dat read after every vid_restart when s_allowDynamicMusic is 0.
10. Seeker legs model not precached on spawning seeker first time on map.
11. Some kyle animation sounds not being precached (start of cairn_assembly/cairn_reactor/meowtrack).
12. Not precached model_fpls.skin (entering cutscenes).
13. noweap.glm not precached on spawning npcs with weapon types using noweap model (e.g. artus_mine cave entrance).

### Fixes
1-3. Add `NPC_Precache` call for client entities in g_entities cycle in `CG_RegisterGraphics`.
4. Make comparison case insenstitive for weequay npc type in `NPC_WeaponsForTeam`.
5-6. Precache items from SET_ITEM, SET_WEAPON inside `ICARUS_InterrogateScript` which is called during `SV_SpawnServer`.
7. Register death_smoke effect in `SP_func_rotating`, burn effect in `CG_RegisterGraphics`.
8. Precache all possible dissolve images in `RE_RegisterMedia_LevelLoadEnd`.
9. Avoid calling `Music_DynamicDataAvailable` from `S_StartBackgroundTrack` when intro is a path and dynamic music is not allowed.
10. Add registration of legs model to `CG_RegisterItemVisuals`.
11. Add `NPC_PrecacheAnimationCFG("kyle")` call to `SP_info_player_deathmatch`.
12. Remove unused skin registration block in `G_SetG2PlayerModel`.
13. Avoid attaching "_w" suffix to `weaponModel` when processing noweap (`NPC_PrecacheWeapons`, `CG_RegisterWeapon`).